### PR TITLE
refactor(ui): use dnd-kit-svelte

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,11 +21,11 @@
         "@dnd-kit-svelte/core": "^0.0.8",
         "@dnd-kit-svelte/utilities": "^0.0.8",
         "@msgpack/msgpack": "3.0.1",
-        "@sveltejs/kit": "^2.9.0",
+        "@sveltejs/kit": "^2.17.2",
         "clsx": "^2.1.1",
-        "svelte": "^5.8.1",
+        "svelte": "^5.20.2",
         "tailwind-merge": "^2.6.0",
-        "valibot": "1.0.0-beta.9"
+        "valibot": "1.0.0-rc.1"
     },
     "devDependencies": {
         "@eslint/js": "^9.20.0",

--- a/client/package.json
+++ b/client/package.json
@@ -18,10 +18,14 @@
         "lint:svelte": "svelte-check --tsconfig ./tsconfig.json"
     },
     "dependencies": {
+        "@dnd-kit-svelte/core": "^0.0.8",
+        "@dnd-kit-svelte/utilities": "^0.0.8",
         "@msgpack/msgpack": "3.0.1",
-        "@sveltejs/kit": "^2.17.2",
-        "svelte": "^5.20.2",
-        "valibot": "1.0.0-rc.1"
+        "@sveltejs/kit": "^2.9.0",
+        "clsx": "^2.1.1",
+        "svelte": "^5.8.1",
+        "tailwind-merge": "^2.6.0",
+        "valibot": "1.0.0-beta.9"
     },
     "devDependencies": {
         "@eslint/js": "^9.20.0",

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -8,18 +8,30 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit-svelte/core':
+        specifier: ^0.0.8
+        version: 0.0.8(svelte@5.20.2)
+      '@dnd-kit-svelte/utilities':
+        specifier: ^0.0.8
+        version: 0.0.8(svelte@5.20.2)
       '@msgpack/msgpack':
         specifier: 3.0.1
         version: 3.0.1
       '@sveltejs/kit':
-        specifier: ^2.17.2
-        version: 2.17.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0)))(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0))
+        specifier: ^2.9.0
+        version: 2.17.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(yaml@2.7.0))
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       svelte:
-        specifier: ^5.20.2
+        specifier: ^5.8.1
         version: 5.20.2
+      tailwind-merge:
+        specifier: ^2.6.0
+        version: 2.6.0
       valibot:
-        specifier: 1.0.0-rc.1
-        version: 1.0.0-rc.1(typescript@5.7.3)
+        specifier: 1.0.0-beta.9
+        version: 1.0.0-beta.9(typescript@5.7.3)
     devDependencies:
       '@eslint/js':
         specifier: ^9.20.0
@@ -32,10 +44,10 @@ importers:
         version: 0.1.0(@linthtml/linthtml@0.10.1(typescript@5.7.3))
       '@sveltejs/adapter-static':
         specifier: ^3.0.8
-        version: 3.0.8(@sveltejs/kit@2.17.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0)))(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0)))
+        version: 3.0.8(@sveltejs/kit@2.17.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(yaml@2.7.0)))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.3
-        version: 5.0.3(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0))
+        version: 5.0.3(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(yaml@2.7.0))
       '@tailwindcss/typography':
         specifier: ^0.5.16
         version: 0.5.16(tailwindcss@3.4.17)
@@ -95,10 +107,10 @@ importers:
         version: 0.3.45(svelte@5.20.2)(typescript@5.7.3)
       vite:
         specifier: ^6.1.1
-        version: 6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0)
+        version: 6.1.1(jiti@1.21.7)(yaml@2.7.0)
       vite-plugin-tailwind-purgecss:
         specifier: ^0.3.5
-        version: 0.3.5(tailwindcss@3.4.17)(vite@6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0))
+        version: 0.3.5(tailwindcss@3.4.17)(vite@6.1.1(jiti@1.21.7)(yaml@2.7.0))
 
 packages:
 
@@ -144,6 +156,21 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       postcss-selector-parser: ^7.0.0
+
+  '@dnd-kit-svelte/accessibility@0.0.8':
+    resolution: {integrity: sha512-Dm+6jTIuorEI4fkOh9ZcbVeJfUAPQGdseT2HfG9gu30PtxHTd9offH5cGWKxsdxjKZjkr5OH2O3DVeNtFjOPxQ==}
+    peerDependencies:
+      svelte: ^5.0.0
+
+  '@dnd-kit-svelte/core@0.0.8':
+    resolution: {integrity: sha512-c77kG70L2DX+af9NW7EbbByKXcHF4y+8sqbZjj81N6QnAtdqrfZdQug/39qSMC3hxLkiS1UowVhSQRJgpdFWGA==}
+    peerDependencies:
+      svelte: ^5.0.0
+
+  '@dnd-kit-svelte/utilities@0.0.8':
+    resolution: {integrity: sha512-fiBPmbHS94cuigysqyRA7T8WpNP94uEw2DsYX9En81mOkAN9UH9RU2DlJ63luZwn4BG9k+DjYT0jt2AEaRuYIg==}
+    peerDependencies:
+      svelte: ^5.0.0
 
   '@dual-bundle/import-meta-resolve@4.1.0':
     resolution: {integrity: sha512-+nxncfwHM5SgAtrVzgpzJOI1ol0PkumhVo469KCf9lUi21IGcY90G98VuHm9VRrUypmAzawAHO9bs6hqeADaVg==}
@@ -371,9 +398,6 @@ packages:
   '@jridgewell/set-array@1.2.1':
     resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
     engines: {node: '>=6.0.0'}
-
-  '@jridgewell/source-map@0.3.6':
-    resolution: {integrity: sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==}
 
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
@@ -736,9 +760,6 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  buffer-from@1.1.2:
-    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
@@ -838,9 +859,6 @@ packages:
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
-
-  commander@2.20.3:
-    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -1292,6 +1310,9 @@ packages:
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  inline-style-parser@0.2.4:
+    resolution: {integrity: sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==}
 
   inquirer@9.3.7:
     resolution: {integrity: sha512-LJKFHCSeIRq9hanN14IlOtPSTe3lNES7TYDTE2xxdAy1LS5rYphajK1qtwvj3YmQXvvk0U2Vbmcni8P9EIQW9w==}
@@ -1909,6 +1930,11 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  runed@0.23.4:
+    resolution: {integrity: sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA==}
+    peerDependencies:
+      svelte: ^5.7.0
+
   rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
 
@@ -1965,13 +1991,6 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
-  source-map-support@0.5.21:
-    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
-
-  source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
-    engines: {node: '>=0.10.0'}
-
   spdx-correct@3.2.0:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
 
@@ -2014,6 +2033,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  style-to-object@1.0.8:
+    resolution: {integrity: sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g==}
 
   stylelint-config-recommended@15.0.0:
     resolution: {integrity: sha512-9LejMFsat7L+NXttdHdTq94byn25TD+82bzGRiV1Pgasl99pWnwipXS5DguTpp3nP1XjvLXVnEJIuYBfsRjRkA==}
@@ -2072,6 +2094,12 @@ packages:
       svelte:
         optional: true
 
+  svelte-toolbelt@0.7.1:
+    resolution: {integrity: sha512-HcBOcR17Vx9bjaOceUvxkY3nGmbBmCBBbuWLLEWO6jtmWH8f/QoWmbyUfQZrpDINH39en1b8mptfPQT9VKQ1xQ==}
+    engines: {node: '>=18', pnpm: '>=8.7.0'}
+    peerDependencies:
+      svelte: ^5.0.0
+
   svelte2tsx@0.7.34:
     resolution: {integrity: sha512-WTMhpNhFf8/h3SMtR5dkdSy2qfveomkhYei/QW9gSPccb0/b82tjHvLop6vT303ZkGswU/da1s6XvrLgthQPCw==}
     peerDependencies:
@@ -2098,14 +2126,12 @@ packages:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
     engines: {node: '>=10.0.0'}
 
+  tailwind-merge@2.6.0:
+    resolution: {integrity: sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==}
+
   tailwindcss@3.4.17:
     resolution: {integrity: sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==}
     engines: {node: '>=14.0.0'}
-    hasBin: true
-
-  terser@5.36.0:
-    resolution: {integrity: sha512-IYV9eNMuFAV4THUspIRXkLakHnV6XO7FEdtKjf/mDyrnqUg9LnlOn6/RwRvM9SZjR4GUq8Nk8zj67FzVARr74w==}
-    engines: {node: '>=10'}
     hasBin: true
 
   thenify-all@1.6.0:
@@ -2194,8 +2220,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  valibot@1.0.0-rc.1:
-    resolution: {integrity: sha512-bTHNpeeQ403xS7qGHF/tw3EC/zkZOU5VdkfIsmRDu1Sp+BJNTNCm6m5HlwOgyW/03lofP+uQiq3R+Poo9wiCEg==}
+  valibot@1.0.0-beta.9:
+    resolution: {integrity: sha512-yEX8gMAZ2R1yI2uwOO4NCtVnJQx36zn3vD0omzzj9FhcoblvPukENIiRZXKZwCnqSeV80bMm8wNiGhQ0S8fiww==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -2366,6 +2392,26 @@ snapshots:
     dependencies:
       postcss-selector-parser: 7.1.0
 
+  '@dnd-kit-svelte/accessibility@0.0.8(svelte@5.20.2)':
+    dependencies:
+      '@dnd-kit-svelte/utilities': 0.0.8(svelte@5.20.2)
+      esm-env: 1.2.2
+      runed: 0.23.4(svelte@5.20.2)
+      svelte: 5.20.2
+
+  '@dnd-kit-svelte/core@0.0.8(svelte@5.20.2)':
+    dependencies:
+      '@dnd-kit-svelte/accessibility': 0.0.8(svelte@5.20.2)
+      '@dnd-kit-svelte/utilities': 0.0.8(svelte@5.20.2)
+      runed: 0.23.4(svelte@5.20.2)
+      svelte: 5.20.2
+      svelte-toolbelt: 0.7.1(svelte@5.20.2)
+
+  '@dnd-kit-svelte/utilities@0.0.8(svelte@5.20.2)':
+    dependencies:
+      svelte: 5.20.2
+      svelte-toolbelt: 0.7.1(svelte@5.20.2)
+
   '@dual-bundle/import-meta-resolve@4.1.0': {}
 
   '@esbuild/aix-ppc64@0.24.2':
@@ -2519,12 +2565,6 @@ snapshots:
 
   '@jridgewell/set-array@1.2.1': {}
 
-  '@jridgewell/source-map@0.3.6':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.8
-      '@jridgewell/trace-mapping': 0.3.25
-    optional: true
-
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
   '@jridgewell/trace-mapping@0.3.25':
@@ -2656,13 +2696,13 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.34.8':
     optional: true
 
-  '@sveltejs/adapter-static@3.0.8(@sveltejs/kit@2.17.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0)))(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0)))':
+  '@sveltejs/adapter-static@3.0.8(@sveltejs/kit@2.17.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(yaml@2.7.0)))':
     dependencies:
-      '@sveltejs/kit': 2.17.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0)))(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0))
+      '@sveltejs/kit': 2.17.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(yaml@2.7.0))
 
-  '@sveltejs/kit@2.17.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0)))(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0))':
+  '@sveltejs/kit@2.17.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(yaml@2.7.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(yaml@2.7.0))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.1.1
@@ -2675,27 +2715,27 @@ snapshots:
       set-cookie-parser: 2.7.1
       sirv: 3.0.1
       svelte: 5.20.2
-      vite: 6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0)
+      vite: 6.1.1(jiti@1.21.7)(yaml@2.7.0)
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0)))(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(yaml@2.7.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(yaml@2.7.0))
       debug: 4.4.0
       svelte: 5.20.2
-      vite: 6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0)
+      vite: 6.1.1(jiti@1.21.7)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0))':
+  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(yaml@2.7.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0)))(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(yaml@2.7.0))
       debug: 4.4.0
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
       svelte: 5.20.2
-      vite: 6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0)
-      vitefu: 1.0.5(vite@6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0))
+      vite: 6.1.1(jiti@1.21.7)(yaml@2.7.0)
+      vitefu: 1.0.5(vite@6.1.1(jiti@1.21.7)(yaml@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -2901,9 +2941,6 @@ snapshots:
       node-releases: 2.0.19
       update-browserslist-db: 1.1.2(browserslist@4.24.4)
 
-  buffer-from@1.1.2:
-    optional: true
-
   buffer@5.7.1:
     dependencies:
       base64-js: 1.5.1
@@ -3006,9 +3043,6 @@ snapshots:
       typical: 7.3.0
 
   commander@12.1.0: {}
-
-  commander@2.20.3:
-    optional: true
 
   commander@4.1.1: {}
 
@@ -3492,6 +3526,8 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
+
+  inline-style-parser@0.2.4: {}
 
   inquirer@9.3.7:
     dependencies:
@@ -4025,6 +4061,11 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  runed@0.23.4(svelte@5.20.2):
+    dependencies:
+      esm-env: 1.2.2
+      svelte: 5.20.2
+
   rxjs@7.8.1:
     dependencies:
       tslib: 2.8.1
@@ -4068,15 +4109,6 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
 
   source-map-js@1.2.1: {}
-
-  source-map-support@0.5.21:
-    dependencies:
-      buffer-from: 1.1.2
-      source-map: 0.6.1
-    optional: true
-
-  source-map@0.6.1:
-    optional: true
 
   spdx-correct@3.2.0:
     dependencies:
@@ -4123,6 +4155,10 @@ snapshots:
       min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
+
+  style-to-object@1.0.8:
+    dependencies:
+      inline-style-parser: 0.2.4
 
   stylelint-config-recommended@15.0.0(stylelint@16.14.1(typescript@5.7.3)):
     dependencies:
@@ -4225,6 +4261,13 @@ snapshots:
     optionalDependencies:
       svelte: 5.20.2
 
+  svelte-toolbelt@0.7.1(svelte@5.20.2):
+    dependencies:
+      clsx: 2.1.1
+      runed: 0.23.4(svelte@5.20.2)
+      style-to-object: 1.0.8
+      svelte: 5.20.2
+
   svelte2tsx@0.7.34(svelte@5.20.2)(typescript@5.7.3):
     dependencies:
       dedent-js: 1.0.1
@@ -4274,6 +4317,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  tailwind-merge@2.6.0: {}
+
   tailwindcss@3.4.17:
     dependencies:
       '@alloc/quick-lru': 5.2.0
@@ -4300,14 +4345,6 @@ snapshots:
       sucrase: 3.35.0
     transitivePeerDependencies:
       - ts-node
-
-  terser@5.36.0:
-    dependencies:
-      '@jridgewell/source-map': 0.3.6
-      acorn: 8.14.0
-      commander: 2.20.3
-      source-map-support: 0.5.21
-    optional: true
 
   thenify-all@1.6.0:
     dependencies:
@@ -4383,7 +4420,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  valibot@1.0.0-rc.1(typescript@5.7.3):
+  valibot@1.0.0-beta.9(typescript@5.7.3):
     optionalDependencies:
       typescript: 5.7.3
 
@@ -4392,7 +4429,7 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  vite-plugin-tailwind-purgecss@0.3.5(tailwindcss@3.4.17)(vite@6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0)):
+  vite-plugin-tailwind-purgecss@0.3.5(tailwindcss@3.4.17)(vite@6.1.1(jiti@1.21.7)(yaml@2.7.0)):
     dependencies:
       chalk: 5.4.1
       css-tree: 2.3.1
@@ -4400,9 +4437,9 @@ snapshots:
       purgecss: 6.0.0
       purgecss-from-html: 6.0.0
       tailwindcss: 3.4.17
-      vite: 6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0)
+      vite: 6.1.1(jiti@1.21.7)(yaml@2.7.0)
 
-  vite@6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0):
+  vite@6.1.1(jiti@1.21.7)(yaml@2.7.0):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.5.3
@@ -4410,12 +4447,11 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
       jiti: 1.21.7
-      terser: 5.36.0
       yaml: 2.7.0
 
-  vitefu@1.0.5(vite@6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0)):
+  vitefu@1.0.5(vite@6.1.1(jiti@1.21.7)(yaml@2.7.0)):
     optionalDependencies:
-      vite: 6.1.1(jiti@1.21.7)(terser@5.36.0)(yaml@2.7.0)
+      vite: 6.1.1(jiti@1.21.7)(yaml@2.7.0)
 
   wcwidth@1.0.1:
     dependencies:

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -18,20 +18,20 @@ importers:
         specifier: 3.0.1
         version: 3.0.1
       '@sveltejs/kit':
-        specifier: ^2.9.0
+        specifier: ^2.17.2
         version: 2.17.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.20.2)(vite@6.1.1(jiti@1.21.7)(yaml@2.7.0))
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
       svelte:
-        specifier: ^5.8.1
+        specifier: ^5.20.2
         version: 5.20.2
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0
       valibot:
-        specifier: 1.0.0-beta.9
-        version: 1.0.0-beta.9(typescript@5.7.3)
+        specifier: 1.0.0-rc.1
+        version: 1.0.0-rc.1(typescript@5.7.3)
     devDependencies:
       '@eslint/js':
         specifier: ^9.20.0
@@ -2220,8 +2220,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  valibot@1.0.0-beta.9:
-    resolution: {integrity: sha512-yEX8gMAZ2R1yI2uwOO4NCtVnJQx36zn3vD0omzzj9FhcoblvPukENIiRZXKZwCnqSeV80bMm8wNiGhQ0S8fiww==}
+  valibot@1.0.0-rc.1:
+    resolution: {integrity: sha512-bTHNpeeQ403xS7qGHF/tw3EC/zkZOU5VdkfIsmRDu1Sp+BJNTNCm6m5HlwOgyW/03lofP+uQiq3R+Poo9wiCEg==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -4420,7 +4420,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  valibot@1.0.0-beta.9(typescript@5.7.3):
+  valibot@1.0.0-rc.1(typescript@5.7.3):
     optionalDependencies:
       typescript: 5.7.3
 

--- a/client/src/lib/components/zzz/ActionButton.svelte
+++ b/client/src/lib/components/zzz/ActionButton.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
     import { cn } from '$lib/utils/cn';
 
-    const { class: externalClass = '', action } = $props();
+    const { class: externalClass = '', action, disabled } = $props();
 </script>
 
-<div
+<button
+    {disabled}
     class={cn(externalClass, 'btn btn-circle btn-lg z-10 ring-offset-neutral', {
         'btn-info': action === 'Zip',
         'btn-success': action === 'Zap',
@@ -12,4 +13,4 @@
     })}
 >
     {action}
-</div>
+</button>

--- a/client/src/lib/components/zzz/ActionButton.svelte
+++ b/client/src/lib/components/zzz/ActionButton.svelte
@@ -1,18 +1,15 @@
 <script lang="ts">
-    const { action } = $props();
+    import { cn } from '$lib/utils/cn';
 
-    function buttonColorClasses(action: string) {
-        switch (action) {
-            case 'Zip':
-                return 'btn-info';
-            case 'Zap':
-                return 'btn-success';
-            case 'Zop':
-                return 'btn-warning';
-        }
-    }
+    const { class: externalClass = '', action } = $props();
 </script>
 
-<div class="btn btn-circle btn-lg z-10 ring-offset-neutral {buttonColorClasses(action)}">
+<div
+    class={cn(externalClass, 'btn btn-circle btn-lg z-10 ring-offset-neutral', {
+        'btn-info': action === 'Zip',
+        'btn-success': action === 'Zap',
+        'btn-warning': action === 'Zop',
+    })}
+>
     {action}
 </div>

--- a/client/src/lib/components/zzz/ActionButton.svelte
+++ b/client/src/lib/components/zzz/ActionButton.svelte
@@ -1,16 +1,23 @@
 <script lang="ts">
     import { cn } from '$lib/utils/cn';
 
+    function buttonColorClasses(action: string) {
+        switch (action) {
+            case 'Zip':
+                return 'btn-info';
+            case 'Zap':
+                return 'btn-success';
+            case 'Zop':
+                return 'btn-warning';
+        }
+    }
+
     const { class: externalClass = '', action, disabled } = $props();
 </script>
 
 <button
     {disabled}
-    class={cn(externalClass, 'btn btn-circle btn-lg z-10 ring-offset-neutral', {
-        'btn-info': action === 'Zip',
-        'btn-success': action === 'Zap',
-        'btn-warning': action === 'Zop',
-    })}
+    class={cn(externalClass, 'btn btn-circle btn-lg z-10 ring-offset-neutral', buttonColorClasses(action))}
 >
     {action}
 </button>

--- a/client/src/lib/components/zzz/ActionButton.svelte
+++ b/client/src/lib/components/zzz/ActionButton.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+    const { action } = $props();
+
+    function buttonColorClasses(action: string) {
+        switch (action) {
+            case 'Zip':
+                return 'btn-info';
+            case 'Zap':
+                return 'btn-success';
+            case 'Zop':
+                return 'btn-warning';
+        }
+    }
+</script>
+
+<div class="btn btn-circle btn-lg z-10 ring-offset-neutral {buttonColorClasses(action)}">
+    {action}
+</div>

--- a/client/src/lib/components/zzz/ActionButton.svelte
+++ b/client/src/lib/components/zzz/ActionButton.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
     import { cn } from '$lib/utils/cn';
 
+    interface Props {
+        class?: string;
+        action: string;
+        disabled: boolean;
+    }
+    const { class: className, action, disabled }: Props = $props();
+
     function buttonColorClasses(action: string) {
         switch (action) {
             case 'Zip':
@@ -11,13 +18,8 @@
                 return 'btn-warning';
         }
     }
-
-    const { class: externalClass = '', action, disabled } = $props();
 </script>
 
-<button
-    {disabled}
-    class={cn(externalClass, 'btn btn-circle btn-lg z-10 ring-offset-neutral', buttonColorClasses(action))}
->
+<button {disabled} class={cn(className, 'btn btn-circle btn-lg z-10 ring-offset-neutral', buttonColorClasses(action))}>
     {action}
 </button>

--- a/client/src/lib/components/zzz/Draggable.svelte
+++ b/client/src/lib/components/zzz/Draggable.svelte
@@ -1,29 +1,15 @@
 <script lang="ts">
+    import ActionButton from './ActionButton.svelte';
     import { CSS } from '@dnd-kit-svelte/utilities';
     import { useDraggable } from '@dnd-kit-svelte/core';
 
     const { id } = $props();
-    const { transform, listeners, attributes, node } = useDraggable({ id });
-    const style = $derived(transform.current ? `transform: ${CSS.Translate.toString(transform.current)}` : '');
-
-    function buttonColorClasses(id: string) {
-        switch (id) {
-            case 'Zip':
-                return 'btn-info';
-            case 'Zap':
-                return 'btn-success';
-            case 'Zop':
-                return 'btn-warning';
-        }
-    }
+    const { transform, listeners, attributes, node, isDragging } = useDraggable({ id });
+    const style = $derived(
+        transform.current && !isDragging ? `transform: ${CSS.Translate.toString(transform.current)}` : '',
+    );
 </script>
 
-<div
-    class="btn btn-circle btn-lg z-10 ring-offset-neutral {buttonColorClasses(id)}"
-    {style}
-    bind:this={node.current}
-    {...attributes.current}
-    {...listeners.current}
->
-    {id}
+<div {style} bind:this={node.current} {...attributes.current} {...listeners.current}>
+    <ActionButton action={id} />
 </div>

--- a/client/src/lib/components/zzz/Draggable.svelte
+++ b/client/src/lib/components/zzz/Draggable.svelte
@@ -4,8 +4,8 @@
     import { cn } from '$lib/utils/cn';
     import { useDraggable } from '@dnd-kit-svelte/core';
 
-    const { id } = $props();
-    const { transform, listeners, attributes, node, isDragging } = useDraggable({ id });
+    const { id, disabled } = $props();
+    const { transform, listeners, attributes, node, isDragging } = useDraggable({ id, disabled: () => disabled });
     const style = $derived(
         transform.current && !isDragging.current ? `transform: ${CSS.Translate.toString(transform.current)}` : '',
     );
@@ -13,6 +13,7 @@
 
 <div {style} bind:this={node.current} {...attributes.current} {...listeners.current}>
     <ActionButton
+        {disabled}
         class={cn(
             { 'btn-ghost ring-2 ring-offset-2': isDragging.current },
             isDragging.current && {

--- a/client/src/lib/components/zzz/Draggable.svelte
+++ b/client/src/lib/components/zzz/Draggable.svelte
@@ -4,7 +4,12 @@
     import { cn } from '$lib/utils/cn';
     import { useDraggable } from '@dnd-kit-svelte/core';
 
-    const { id, disabled } = $props();
+    interface Props {
+        id: string;
+        disabled: boolean;
+    }
+
+    const { id, disabled }: Props = $props();
     const { transform, listeners, attributes, node, isDragging } = useDraggable({ id, disabled: () => disabled });
     const style = $derived(
         transform.current && !isDragging.current ? `transform: ${CSS.Translate.toString(transform.current)}` : '',

--- a/client/src/lib/components/zzz/Draggable.svelte
+++ b/client/src/lib/components/zzz/Draggable.svelte
@@ -1,15 +1,26 @@
 <script lang="ts">
     import ActionButton from './ActionButton.svelte';
     import { CSS } from '@dnd-kit-svelte/utilities';
+    import { cn } from '$lib/utils/cn';
     import { useDraggable } from '@dnd-kit-svelte/core';
 
     const { id } = $props();
     const { transform, listeners, attributes, node, isDragging } = useDraggable({ id });
     const style = $derived(
-        transform.current && !isDragging ? `transform: ${CSS.Translate.toString(transform.current)}` : '',
+        transform.current && !isDragging.current ? `transform: ${CSS.Translate.toString(transform.current)}` : '',
     );
 </script>
 
 <div {style} bind:this={node.current} {...attributes.current} {...listeners.current}>
-    <ActionButton action={id} />
+    <ActionButton
+        class={cn(
+            { 'btn-ghost ring-2 ring-offset-2': isDragging.current },
+            isDragging.current && {
+                'ring-info': id === 'Zip',
+                'ring-success': id === 'Zap',
+                'ring-warning': id === 'Zop',
+            },
+        )}
+        action={id}
+    />
 </div>

--- a/client/src/lib/components/zzz/Draggable.svelte
+++ b/client/src/lib/components/zzz/Draggable.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+    import { CSS } from '@dnd-kit-svelte/utilities';
+    import { useDraggable } from '@dnd-kit-svelte/core';
+
+    const { id } = $props();
+    const { transform, listeners, attributes, node } = useDraggable({ id });
+    const style = $derived(transform.current ? `transform: ${CSS.Translate.toString(transform.current)}` : '');
+
+    function buttonColorClasses(id: string) {
+        switch (id) {
+            case 'Zip':
+                return 'btn-info';
+            case 'Zap':
+                return 'btn-success';
+            case 'Zop':
+                return 'btn-warning';
+        }
+    }
+</script>
+
+<div
+    class="btn btn-circle btn-lg z-10 ring-offset-neutral {buttonColorClasses(id)}"
+    {style}
+    bind:this={node.current}
+    {...attributes.current}
+    {...listeners.current}
+>
+    {id}
+</div>

--- a/client/src/lib/components/zzz/Draggable.svelte
+++ b/client/src/lib/components/zzz/Draggable.svelte
@@ -9,19 +9,23 @@
     const style = $derived(
         transform.current && !isDragging.current ? `transform: ${CSS.Translate.toString(transform.current)}` : '',
     );
+
+    function ringColorClasses(action: string) {
+        switch (action) {
+            case 'Zip':
+                return 'ring-info';
+            case 'Zap':
+                return 'ring-success';
+            case 'Zop':
+                return 'ring-warning';
+        }
+    }
 </script>
 
 <div {style} bind:this={node.current} {...attributes.current} {...listeners.current}>
     <ActionButton
         {disabled}
-        class={cn(
-            { 'btn-ghost ring-2 ring-offset-2': isDragging.current },
-            isDragging.current && {
-                'ring-info': id === 'Zip',
-                'ring-success': id === 'Zap',
-                'ring-warning': id === 'Zop',
-            },
-        )}
+        class={cn(isDragging.current && `btn-ghost ring-2 ring-offset-2 ${ringColorClasses(id)}`)}
         action={id}
     />
 </div>

--- a/client/src/lib/components/zzz/Droppable.svelte
+++ b/client/src/lib/components/zzz/Droppable.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { type UseDroppableArguments, useDroppable } from '@dnd-kit-svelte/core';
     import type { Snippet } from 'svelte';
+    import { cn } from '$lib/utils/cn';
 
     interface DroppableProps extends UseDroppableArguments {
         children: Snippet;
@@ -11,9 +12,9 @@
 </script>
 
 <div
-    class="rounded-xl border bg-base-300 px-4 py-2 text-neutral-content {droppable.isOver.current
-        ? 'animate-pulse border-neutral-content'
-        : 'border-base-300'}"
+    class={cn('rounded-xl border border-base-300 bg-base-300 px-4 py-2 text-neutral-content', {
+        'animate-pulse border-neutral-content': droppable.isOver.current,
+    })}
     bind:this={droppable.node.current}
 >
     {@render children()}

--- a/client/src/lib/components/zzz/Droppable.svelte
+++ b/client/src/lib/components/zzz/Droppable.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+    import { type UseDroppableArguments, useDroppable } from '@dnd-kit-svelte/core';
+    import type { Snippet } from 'svelte';
+
+    interface DroppableProps extends UseDroppableArguments {
+        children: Snippet;
+    }
+
+    const { children, ...rest }: DroppableProps = $props();
+    const droppable = useDroppable(rest);
+</script>
+
+<div
+    class="rounded-xl border bg-base-300 px-4 py-2 text-neutral-content {droppable.isOver.current
+        ? 'animate-pulse border-neutral-content'
+        : 'border-base-300'}"
+    bind:this={droppable.node.current}
+>
+    {@render children()}
+</div>

--- a/client/src/lib/components/zzz/ZipZapZop.svelte
+++ b/client/src/lib/components/zzz/ZipZapZop.svelte
@@ -85,17 +85,17 @@
 
 <div class="flex overflow-hidden rounded-lg text-3xl shadow-xl">
     {#if zzz.lid !== null}
-        <div class="flex-none bg-primary px-4 py-2 text-primary-content">{zzz.lid}</div>
+        <div class="flex-none place-self-center bg-primary p-4 text-primary-content">{zzz.lid}</div>
     {/if}
     {#if zzz.lobby !== null}
-        <div class="flex-1 bg-neutral px-4 py-2 text-neutral-content">{zzz.lobby}</div>
+        <div class="flex-1 place-self-center bg-neutral p-4 text-neutral-content">{zzz.lobby}</div>
     {/if}
 </div>
 {#if zzz.winner === null}
     {#if zzz.expected === null}
         <div role="alert" class="alert skeleton shadow-sm">Waiting for the host to start the game...</div>
         <div class="overflow-x-auto">
-            <table class="table">
+            <table class="table overflow-y-scroll">
                 <thead>
                     <tr>
                         <th>ID</th>
@@ -149,22 +149,24 @@
             </div>
         {/if}
         <DndContext onDragStart={handleDragStart} onDragEnd={handleDrop}>
-            <div class="flex touch-none select-none flex-row justify-center gap-2">
-                <Draggable id="Zip" {disabled} />
-                <Draggable id="Zap" {disabled} />
-                <Draggable id="Zop" {disabled} />
-            </div>
-            <DragOverlay dropAnimation={null}>
-                {#if typeof draggedButton === 'string'}
-                    <ActionButton {disabled} action={draggedButton} />
-                {/if}
-            </DragOverlay>
-            <div class="grid grid-cols-3 gap-2 md:gap-4 lg:grid-cols-5">
-                {#each zzz.players as [pid, player] (pid)}
-                    <Droppable id={pid}>
-                        <p class="w-full truncate text-center font-bold">{player}</p>
-                    </Droppable>
-                {/each}
+            <div class="flex flex-col gap-4 overflow-hidden">
+                <div class="flex touch-none select-none flex-row justify-center gap-2 p-2">
+                    <Draggable id="Zip" {disabled} />
+                    <Draggable id="Zap" {disabled} />
+                    <Draggable id="Zop" {disabled} />
+                </div>
+                <DragOverlay dropAnimation={null}>
+                    {#if typeof draggedButton === 'string'}
+                        <ActionButton {disabled} action={draggedButton} />
+                    {/if}
+                </DragOverlay>
+                <div class="grid grid-cols-3 gap-2 overflow-auto md:gap-4 lg:grid-cols-5">
+                    {#each zzz.players as [pid, player] (pid)}
+                        <Droppable id={pid}>
+                            <p class="w-full truncate text-center font-bold">{player}</p>
+                        </Droppable>
+                    {/each}
+                </div>
             </div>
         </DndContext>
     {/if}

--- a/client/src/lib/components/zzz/ZipZapZop.svelte
+++ b/client/src/lib/components/zzz/ZipZapZop.svelte
@@ -150,13 +150,13 @@
         {/if}
         <DndContext onDragStart={handleDragStart} onDragEnd={handleDrop}>
             <div class="flex touch-none select-none flex-row justify-center gap-2">
-                <Draggable id="Zip" />
-                <Draggable id="Zap" />
-                <Draggable id="Zop" />
+                <Draggable id="Zip" {disabled} />
+                <Draggable id="Zap" {disabled} />
+                <Draggable id="Zop" {disabled} />
             </div>
             <DragOverlay dropAnimation={null}>
                 {#if typeof draggedButton === 'string'}
-                    <ActionButton action={draggedButton} />
+                    <ActionButton {disabled} action={draggedButton} />
                 {/if}
             </DragOverlay>
             <div class="grid grid-cols-3 gap-2 md:gap-4 lg:grid-cols-5">

--- a/client/src/lib/components/zzz/ZipZapZop.svelte
+++ b/client/src/lib/components/zzz/ZipZapZop.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
-    import { DndContext, type DragEndEvent, type DragStartEvent, type UniqueIdentifier } from '@dnd-kit-svelte/core';
+    import {
+        DndContext,
+        type DragEndEvent,
+        DragOverlay,
+        type DragStartEvent,
+        type UniqueIdentifier,
+    } from '@dnd-kit-svelte/core';
+    import ActionButton from './ActionButton.svelte';
     import Deadline from './Deadline.svelte';
     import Draggable from './Draggable.svelte';
     import Droppable from './Droppable.svelte';
@@ -147,6 +154,11 @@
                 <Draggable id="Zap" />
                 <Draggable id="Zop" />
             </div>
+            <DragOverlay dropAnimation={null}>
+                {#if typeof draggedButton === 'string'}
+                    <ActionButton action={draggedButton} />
+                {/if}
+            </DragOverlay>
             <div class="grid grid-cols-3 gap-2 md:gap-4 lg:grid-cols-5">
                 {#each zzz.players as [pid, player] (pid)}
                     <Droppable id={pid}>

--- a/client/src/lib/components/zzz/ZipZapZop.svelte
+++ b/client/src/lib/components/zzz/ZipZapZop.svelte
@@ -19,8 +19,8 @@
     }
 
     const { zzz }: Props = $props();
-    let targetedPlayer: UniqueIdentifier | null = $state<UniqueIdentifier | null>(null);
-    let draggedButton: UniqueIdentifier | null = $state<UniqueIdentifier | null>(null);
+    let targetedPlayer = $state<UniqueIdentifier | null>(null);
+    let draggedButton = $state<UniqueIdentifier | null>(null);
 
     function prevPlayerAction(action: PlayerAction) {
         switch (action) {

--- a/client/src/lib/components/zzz/ZipZapZop.svelte
+++ b/client/src/lib/components/zzz/ZipZapZop.svelte
@@ -19,9 +19,6 @@
     }
 
     const { zzz }: Props = $props();
-
-    let mousePosition = $state({ x: 0, y: 0 });
-    let dragStartPos = $state({ x: 0, y: 0 });
     let targetedPlayer: UniqueIdentifier | null = $state<UniqueIdentifier | null>(null);
     let draggedButton: UniqueIdentifier | null = $state<UniqueIdentifier | null>(null);
 
@@ -47,26 +44,6 @@
         }
     }
 
-    function playerActionColorClasses(action: PlayerAction) {
-        switch (action) {
-            case PlayerAction.Zip:
-                return ['text-info', 'fill-info'] as const;
-            case PlayerAction.Zap:
-                return ['text-success', 'fill-success'] as const;
-            case PlayerAction.Zop:
-                return ['text-warning', 'fill-warning'] as const;
-        }
-    }
-
-    function positionLineStart(event: PointerEvent) {
-        mousePosition = { x: event.clientX, y: event.clientY };
-        const clickTarget = event.currentTarget;
-        if (clickTarget instanceof HTMLButtonElement) {
-            const btnBounds = clickTarget.getBoundingClientRect();
-            dragStartPos = {
-                x: btnBounds.left + btnBounds.width / 2,
-                y: btnBounds.top + btnBounds.height / 2,
-            };
     function handleDragStart({ active }: DragStartEvent) {
         assert(typeof active.id === 'string');
         draggedButton = active.id;
@@ -132,20 +109,6 @@
         {:else}
             <div role="alert" class="alert alert-error text-error-content shadow-sm">
                 <span><strong>{zzz.eliminated}</strong> has been eliminated.</span>
-            </div>
-        {/if}
-        {#if nextAction !== null && !disabled}
-            {@const [lineColor] = playerActionColorClasses(nextAction)}
-            <div>
-                <svg class="pointer-events-none absolute left-0 top-0 h-full w-full stroke-2 {lineColor}">
-                    <line
-                        x1={dragStartPos.x}
-                        y1={dragStartPos.y}
-                        x2={mousePosition.x}
-                        y2={mousePosition.y}
-                        stroke="currentColor"
-                    />
-                </svg>
             </div>
         {/if}
         <DndContext onDragStart={handleDragStart} onDragEnd={handleDrop}>

--- a/client/src/lib/components/zzz/ZipZapZop.svelte
+++ b/client/src/lib/components/zzz/ZipZapZop.svelte
@@ -5,6 +5,7 @@
     import Droppable from './Droppable.svelte';
     import { PlayerAction } from '$lib/models/game';
     import type { State } from '$lib/zzz/state.svelte';
+    import { assert } from '$lib/utils/assert';
 
     interface Props {
         zzz: State;
@@ -16,18 +17,6 @@
     let dragStartPos = $state({ x: 0, y: 0 });
     let targetedPlayer: UniqueIdentifier | null = $state<UniqueIdentifier | null>(null);
     let draggedButton: UniqueIdentifier | null = $state<UniqueIdentifier | null>(null);
-    const nextAction: PlayerAction | null = $derived.by(() => {
-        switch (draggedButton) {
-            case 'Zip':
-                return PlayerAction.Zip;
-            case 'Zap':
-                return PlayerAction.Zap;
-            case 'Zop':
-                return PlayerAction.Zop;
-            default:
-                return null;
-        }
-    });
 
     function prevPlayerAction(action: PlayerAction) {
         switch (action) {
@@ -72,16 +61,18 @@
                 y: btnBounds.top + btnBounds.height / 2,
             };
     function handleDragStart({ active }: DragStartEvent) {
-        if (active) {
-            draggedButton = active.id as string;
-        }
+        assert(typeof active.id === 'string');
+        draggedButton = active.id;
     }
 
     function handleDrop({ over }: DragEndEvent) {
-        if (over && nextAction) {
-            targetedPlayer = over.id as number;
-            zzz.respond(targetedPlayer, nextAction);
+        if (over !== null && draggedButton !== null) {
+            assert(typeof over.id === 'number');
+            targetedPlayer = over.id;
+            zzz.respond(targetedPlayer, draggedButton as PlayerAction);
         }
+        targetedPlayer = null;
+        draggedButton = null;
     }
 </script>
 

--- a/client/src/lib/utils/assert.ts
+++ b/client/src/lib/utils/assert.ts
@@ -1,0 +1,5 @@
+export function assert(condition: unknown): asserts condition {
+    if (!condition) {
+        throw new Error('Assertion failed.');
+    }
+}

--- a/client/src/lib/utils/assert.ts
+++ b/client/src/lib/utils/assert.ts
@@ -1,5 +1,3 @@
 export function assert(condition: unknown): asserts condition {
-    if (!condition) {
-        throw new Error('Assertion failed.');
-    }
+    if (!condition) throw new Error('Assertion failed.');
 }

--- a/client/src/lib/utils/cn.ts
+++ b/client/src/lib/utils/cn.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+    return twMerge(clsx(inputs));
+}

--- a/client/src/routes/create/+page.svelte
+++ b/client/src/routes/create/+page.svelte
@@ -48,13 +48,15 @@
         </div>
     </form>
 {:else}
-    <main class="m-4 space-y-4">
+    <main class="flex max-h-screen flex-col space-y-4 p-4">
         <ZipZapZop {zzz} />
         {#if isPending}
             {@const disabled = zzz.lid === null || zzz.pid === null}
-            <button type="button" {disabled} onclick={startGame.bind(null, zzz)} class="btn btn-success"
-                >Start Game</button
-            >
+            <div>
+                <button type="button" {disabled} onclick={startGame.bind(null, zzz)} class="btn btn-success"
+                    >Start Game</button
+                >
+            </div>
         {/if}
     </main>
 {/if}

--- a/client/src/routes/join/+page.svelte
+++ b/client/src/routes/join/+page.svelte
@@ -42,5 +42,5 @@
         </div>
     </form>
 {:else}
-    <main class="m-4 space-y-4"><ZipZapZop {zzz} /></main>
+    <main class="flex max-h-screen flex-col space-y-4 p-4"><ZipZapZop {zzz} /></main>
 {/if}


### PR DESCRIPTION
🌟 This PR re-implements the game controls using the **dnd-kit-svelte library** + includes other refactors.

- Draggable elements and drop areas are now components
- More efficient styling in components with Tailwind merge and clsx
- List of player names both in the lobby and in the game screen are now scrollable, keeping important buttons on screen

## To-do
- [ ] Add interactive controls to help screen ( ⌛ in progress)
- [ ] Testing on mobile
- [ ] Snap dragged buttons to center of cursor
- [ ] Snap dragged buttons to grid of player names