### PR TITLE
feat(ui): change layout for mobile

### DIFF
--- a/client/src/lib/components/zzz/ZipZapZop.svelte
+++ b/client/src/lib/components/zzz/ZipZapZop.svelte
@@ -113,11 +113,11 @@
         {/if}
         <DndContext onDragStart={handleDragStart} onDragEnd={handleDrop} onDragCancel={handleDrop}>
             <DragOverlay dropAnimation={null}>
-                    {#if typeof draggedButton === 'string'}
-                        <ActionButton {disabled} action={draggedButton} />
-                    {/if}
+                {#if typeof draggedButton === 'string'}
+                    <ActionButton {disabled} action={draggedButton} />
+                {/if}
             </DragOverlay>
-            <div class="flex flex-col gap-4 overflow-hidden">
+            <div class="flex grow flex-col-reverse justify-between gap-4 overflow-hidden md:flex-col md:justify-normal">
                 <div class="flex touch-none select-none flex-row justify-center gap-2 p-2">
                     <Draggable id="Zip" {disabled} />
                     <Draggable id="Zap" {disabled} />

--- a/client/src/lib/components/zzz/ZipZapZop.svelte
+++ b/client/src/lib/components/zzz/ZipZapZop.svelte
@@ -111,18 +111,18 @@
                 <span><strong>{zzz.eliminated}</strong> has been eliminated.</span>
             </div>
         {/if}
-        <DndContext onDragStart={handleDragStart} onDragEnd={handleDrop}>
+        <DndContext onDragStart={handleDragStart} onDragEnd={handleDrop} onDragCancel={handleDrop}>
+            <DragOverlay dropAnimation={null}>
+                    {#if typeof draggedButton === 'string'}
+                        <ActionButton {disabled} action={draggedButton} />
+                    {/if}
+            </DragOverlay>
             <div class="flex flex-col gap-4 overflow-hidden">
                 <div class="flex touch-none select-none flex-row justify-center gap-2 p-2">
                     <Draggable id="Zip" {disabled} />
                     <Draggable id="Zap" {disabled} />
                     <Draggable id="Zop" {disabled} />
                 </div>
-                <DragOverlay dropAnimation={null}>
-                    {#if typeof draggedButton === 'string'}
-                        <ActionButton {disabled} action={draggedButton} />
-                    {/if}
-                </DragOverlay>
                 <div class="grid grid-cols-3 gap-2 overflow-auto md:gap-4 lg:grid-cols-5">
                     {#each zzz.players as [pid, player] (pid)}
                         <Droppable id={pid}>

--- a/client/src/routes/create/+page.svelte
+++ b/client/src/routes/create/+page.svelte
@@ -48,7 +48,7 @@
         </div>
     </form>
 {:else}
-    <main class="flex h-screen flex-col space-y-4 p-4">
+    <main class="flex h-dvh flex-col space-y-4 p-4 md:h-screen">
         <ZipZapZop {zzz} />
         {#if isPending}
             {@const disabled = zzz.lid === null || zzz.pid === null}

--- a/client/src/routes/create/+page.svelte
+++ b/client/src/routes/create/+page.svelte
@@ -48,7 +48,7 @@
         </div>
     </form>
 {:else}
-    <main class="flex max-h-screen flex-col space-y-4 p-4">
+    <main class="flex h-screen flex-col space-y-4 p-4">
         <ZipZapZop {zzz} />
         {#if isPending}
             {@const disabled = zzz.lid === null || zzz.pid === null}

--- a/client/src/routes/help/+page.svelte
+++ b/client/src/routes/help/+page.svelte
@@ -1,3 +1,23 @@
+<script lang="ts">
+    import { DndContext, DragOverlay, type DragStartEvent, type UniqueIdentifier } from '@dnd-kit-svelte/core';
+    import ActionButton from '$lib/components/zzz/ActionButton.svelte';
+    import Draggable from '$lib/components/zzz/Draggable.svelte';
+    import Droppable from '$lib/components/zzz/Droppable.svelte';
+    import { assert } from '$lib/utils/assert';
+
+    const players: [number, string][] = [
+        [0, 'Player A'],
+        [1, 'Player B'],
+        [2, 'Player C'],
+    ];
+    let draggedButton = $state<UniqueIdentifier | null>(null);
+
+    function handleDragStart({ active }: DragStartEvent) {
+        assert(typeof active.id === 'string');
+        draggedButton = active.id;
+    }
+</script>
+
 <div class="flex flex-col items-center justify-center p-12">
     <div class="prose max-w-full">
         <h2>Help</h2>
@@ -23,6 +43,38 @@
             on).
         </p>
         <p>The last player standing wins the game!</p>
-        <a class="btn btn-primary text-primary-content" href="/">Okay!</a>
+
+        <h2>Controls</h2>
+        <p>
+            To play, drag your intended action (Zip, Zap, or Zop) and drop it on your targeted player. Remember to only
+            act on your turn!
+        </p>
+        <DndContext onDragStart={handleDragStart} onDragEnd={() => (draggedButton = null)}>
+            <div class="space-y-4">
+                <div class="flex touch-none select-none flex-row justify-center gap-2 p-2">
+                    <Draggable id="Zip" disabled={false} />
+                    <Draggable id="Zap" disabled={false} />
+                    <Draggable id="Zop" disabled={false} />
+                </div>
+                <DragOverlay dropAnimation={null}>
+                    {#if typeof draggedButton === 'string'}
+                        <ActionButton action={draggedButton} disabled={false} />
+                    {/if}
+                </DragOverlay>
+                <div class="flex justify-center gap-4">
+                    {#each players as [pid, player]}
+                        <Droppable id={pid}>
+                            <p class="m-0 text-center">{player}</p>
+                        </Droppable>
+                    {/each}
+                </div>
+            </div>
+        </DndContext>
+        <div class="flex flex-col items-center md:items-start">
+            <p>Ready to play?</p>
+            <div>
+                <a class="btn btn-primary text-primary-content" href="/">Yes!</a>
+            </div>
+        </div>
     </div>
 </div>

--- a/client/src/routes/help/+page.svelte
+++ b/client/src/routes/help/+page.svelte
@@ -49,18 +49,22 @@
             To play, drag your intended action (Zip, Zap, or Zop) and drop it on your targeted player. Remember to only
             act on your turn!
         </p>
-        <DndContext onDragStart={handleDragStart} onDragEnd={() => (draggedButton = null)}>
+        <DndContext
+            onDragStart={handleDragStart}
+            onDragEnd={() => (draggedButton = null)}
+            onDragCancel={() => (draggedButton = null)}
+        >
+            <DragOverlay dropAnimation={null}>
+                {#if typeof draggedButton === 'string'}
+                    <ActionButton action={draggedButton} disabled={false} />
+                {/if}
+            </DragOverlay>
             <div class="space-y-4">
                 <div class="flex touch-none select-none flex-row justify-center gap-2 p-2">
                     <Draggable id="Zip" disabled={false} />
                     <Draggable id="Zap" disabled={false} />
                     <Draggable id="Zop" disabled={false} />
                 </div>
-                <DragOverlay dropAnimation={null}>
-                    {#if typeof draggedButton === 'string'}
-                        <ActionButton action={draggedButton} disabled={false} />
-                    {/if}
-                </DragOverlay>
                 <div class="flex justify-center gap-4">
                     {#each players as [pid, player]}
                         <Droppable id={pid}>

--- a/client/src/routes/join/+page.svelte
+++ b/client/src/routes/join/+page.svelte
@@ -42,5 +42,5 @@
         </div>
     </form>
 {:else}
-    <main class="flex max-h-screen flex-col space-y-4 p-4"><ZipZapZop {zzz} /></main>
+    <main class="flex h-screen flex-col space-y-4 p-4"><ZipZapZop {zzz} /></main>
 {/if}

--- a/client/src/routes/join/+page.svelte
+++ b/client/src/routes/join/+page.svelte
@@ -42,5 +42,5 @@
         </div>
     </form>
 {:else}
-    <main class="flex h-screen flex-col space-y-4 p-4"><ZipZapZop {zzz} /></main>
+    <main class="flex h-dvh flex-col space-y-4 p-4 md:h-screen"><ZipZapZop {zzz} /></main>
 {/if}


### PR DESCRIPTION
🎀 This PR tweaks the game screen layout for mobile devices.

- Buttons are placed at the bottom for smaller screens
- The help screen now includes an interactive section for trying the drag and drop controls